### PR TITLE
WIP: BREAKING: CallCounter: Add initial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ app.use("/weather", new Service({
 - `mode` (*optional*, default: `'json'`) - the results format (possible: `'json'`, `'xml'`, `'html'`)
 - `lang` (*optional*, default: `'en'`) - the language of the result. [info](https://openweathermap.org/current#multi)
 - `units` (*optional*, default: `'standard'`) - Units of measurement. `'standard'`, `'metric'` and `'imperial'` units are available.
+- `call_minute` (*optional*, default: `60`) - Maximum number of request per minute (free plan). Set to 0 to disable.
+- `call_hour` (*optional*, default: `3600`) - Maximum number of request per hour (free plan). Set to 0 to disable.
+- `call_day` (*optional*, default: `35714`) - Maximum number of request per 24h, current default is 1,000,000 api call per month divided by 28 days (free plan).  Set to 0 to disable.
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,43 @@ app.use("/weather", new Service({
 - `mode` (*optional*, default: `'json'`) - the results format (possible: `'json'`, `'xml'`, `'html'`)
 - `lang` (*optional*, default: `'en'`) - the language of the result. [info](https://openweathermap.org/current#multi)
 - `units` (*optional*, default: `'standard'`) - Units of measurement. `'standard'`, `'metric'` and `'imperial'` units are available.
+- `limits` (*optional*, default: See below `limits` object)
+- `plan` (*optional*, default: Plan.Free)
+- `plan_throttle` (*optional*, default: true), calculate limits based on the maximum number of monthly requests.
+
+
+
+### Call counter and limiter
+
+#### Plans
+The the plan option to one of the following:
+| Type of call  | Plan.Free | Plan.Startup | Plan.Developer | Plan.Pro | Plan.Enterprise |
+|--|------|---------|-----------|-----|------------|
+| Weather API - Minute | 60 | 600 | 3,000 | 30,000 | 200,000 |
+| Weather API - Month | 1,000,000 | 10,000,000 | 100,000,000 | 1,000,000,000 | 5,000,000,000 |
+| One Call API - Minute | 1,000/day | 2,000/day | 3,000 | 30,000 | 200,000 |
+| One Call API - Month | 30,000 | 60,000 | 100,000,000 | 1,000,000,000 | 5,000,000,000 |
+
+Define the plan you have with `options.plan`. Default is Plan.Free.
+
+#### Throttle
+Using OWM values, we can do 60 calls per minutes, up to a million per month. This means we could use all our available calls in 15 days or so when calling OWM non-stop. When throttle is enabled, the limits are calculated based on the monthly maximum calls, divided by 30 days and they by hours and minutes.
+
+On the Free plan this mean we can make 1388 calls per hour and 23 calls per minutes (1,000,000 / 30 days / 24 hours / 60 minutes). when the limit is reached we do not send the request to OWM and return a `TooManyRequests` error.
+
+For the Onecall API, there is no minute limiter for now, as the free plan allow for less than 1 request per minute. Hour limits are calculated 
+
+#### Custom limits
+```
+limits: {
+  minute: 0,
+  hour: 0,
+  day: 0,
+  onecall_hour: 0,
+  onecall_day: 0
+},
+```
+
 - `call_minute` (*optional*, default: `60`) - Maximum number of request per minute (free plan). Set to 0 to disable.
 - `call_hour` (*optional*, default: `3600`) - Maximum number of request per hour (free plan). Set to 0 to disable.
 - `call_day` (*optional*, default: `35714`) - Maximum number of request per 24h, current default is 1,000,000 api call per month divided by 28 days (free plan).  Set to 0 to disable.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ app.use("/weather", new Service({
 
 
 
-### Call counter and limiter
+### API Call counter and limiter
+
+By default, the selected  `plan` is the Free tier and `plan_throttle` is enabled to make sure you have enough calls to go through the month.
 
 #### Plans
 The the plan option to one of the following:
@@ -66,11 +68,15 @@ Define the plan you have with `options.plan`. Default is Plan.Free.
 #### Throttle
 Using OWM values, we can do 60 calls per minutes, up to a million per month. This means we could use all our available calls in 15 days or so when calling OWM non-stop. When throttle is enabled, the limits are calculated based on the monthly maximum calls, divided by 30 days and they by hours and minutes.
 
-On the Free plan this mean we can make 1388 calls per hour and 23 calls per minutes (1,000,000 / 30 days / 24 hours / 60 minutes). when the limit is reached we do not send the request to OWM and return a `TooManyRequests` error.
+Exmaple: On the Free plan this mean we can make 1388 calls per hour and 23 calls per minutes (1,000,000 / 30 days / 24 hours / 60 minutes). When the limit is reached we do not send the request to OWM and return a `TooManyRequests` error.
 
-For the Onecall API, there is no minute limiter for now, as the free plan allow for less than 1 request per minute. Hour limits are calculated 
+For the Onecall API, there is no minute limiter on the free plan as it would allow for less than 1 request per minute. Hour limits are still calculated.
 
 #### Custom limits
+Throttle or not, feel free to set the limits you want!
+- A value of 0 mean this value won't be limited.
+- If you only provide `day` limits and `plan_throttle` is `true` , we will calculate hour and minute limits (Same if you set hour limits)
+
 ```
 limits: {
   minute: 0,
@@ -80,10 +86,6 @@ limits: {
   onecall_day: 0
 },
 ```
-
-- `call_minute` (*optional*, default: `60`) - Maximum number of request per minute (free plan). Set to 0 to disable.
-- `call_hour` (*optional*, default: `3600`) - Maximum number of request per hour (free plan). Set to 0 to disable.
-- `call_day` (*optional*, default: `35714`) - Maximum number of request per 24h, current default is 1,000,000 api call per month divided by 28 days (free plan).  Set to 0 to disable.
 
 ## Methods
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,15 +8,25 @@ export interface OWMServiceOptions {
   lang: Lang
   mode: Mode
   units: Unit,
-  limit_minute: number,
-  limit_hour: number,
-  limit_day: number
-}
+  plan: Plan,
+  limits: CallCounterLimits,
+  plan_throttle: boolean
 
-export interface CallCounter {
+}
+export enum Plan {
+	"Free",
+	"Startup",
+	"Developer",
+	"Pro",
+	"Enterprise"
+}
+export interface CallCounterLimits {
 	minute: number,
 	hour: number,
 	day: number,
+	onecall_minute: number,
+	onecall_hour: number,
+	onecall_day: number,
 }
 
 export interface WithAppId {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,7 +7,16 @@ export interface OWMServiceOptions {
   v: string
   lang: Lang
   mode: Mode
-  units: Unit
+  units: Unit,
+  limit_minute: number,
+  limit_hour: number,
+  limit_day: number
+}
+
+export interface CallCounter {
+	minute: number,
+	hour: number,
+	day: number,
 }
 
 export interface WithAppId {


### PR DESCRIPTION
Gathering feedback. I don't know much of TS and I also want to keep this simple-ish.

This implement a basic api call counter per minute, hour and day in order to avoid calling the OWM server if we are above the limit. This PR should be considered breaking change as users that are not on the free plan need to put custom limits.

There is a timeout function called every minute to clear a minute variable, same goes for hour and day. The counter is incremented in `makeRequest` method.

I realized after the commit I did a small oopsie. The One Call API have different rates. I'm not sure how to make the options so it's not too confusing.

The purpose of minute and hour is that if the server is restarted the daily counter will be lost and it's a big time frame. Using minute and hour allow us to better manage how we use the OWM limit.

## New Readme section
### API Call counter and limiter

By default, the selected  `plan` is the Free tier and `plan_throttle` is enabled to make sure you have enough calls to go through the month.

#### Plans
The the plan option to one of the following:
| Type of call  | Plan.Free | Plan.Startup | Plan.Developer | Plan.Pro | Plan.Enterprise |
|--|------|---------|-----------|-----|------------|
| Weather API - Minute | 60 | 600 | 3,000 | 30,000 | 200,000 |
| Weather API - Month | 1,000,000 | 10,000,000 | 100,000,000 | 1,000,000,000 | 5,000,000,000 |
| One Call API - Minute | 1,000/day | 2,000/day | 3,000 | 30,000 | 200,000 |
| One Call API - Month | 30,000 | 60,000 | 100,000,000 | 1,000,000,000 | 5,000,000,000 |

Define the plan you have with `options.plan`. Default is Plan.Free.

#### Throttle
Using OWM values, we can do 60 calls per minutes, up to a million per month. This means we could use all our available calls in 15 days or so when calling OWM non-stop. When throttle is enabled, the limits are calculated based on the monthly maximum calls, divided by 30 days and they by hours and minutes.

Exmaple: On the Free plan this mean we can make 1388 calls per hour and 23 calls per minutes (1,000,000 / 30 days / 24 hours / 60 minutes). When the limit is reached we do not send the request to OWM and return a `TooManyRequests` error.

For the Onecall API, there is no minute limiter on the free plan as it would allow for less than 1 request per minute. Hour limits are still calculated.

#### Custom limits
Throttle or not, feel free to set the limits you want!
- A value of 0 mean this value won't be limited.
- If you only provide `day` limits and `plan_throttle` is `true` , we will calculate hour and minute limits (Same if you set hour limits)

```
limits: {
  minute: 0,
  hour: 0,
  day: 0,
  onecall_hour: 0,
  onecall_day: 0
},
```

Fix #1 